### PR TITLE
ユーザ一覧表示の処理を軽量化。

### DIFF
--- a/Controller/UsersController.php
+++ b/Controller/UsersController.php
@@ -205,8 +205,9 @@ class UsersController extends AppController
 			$this->Session->write('Iroha.group_id', intval($this->request->query['group_id']));
 
 		// GETパラメータから検索条件を抽出
-		$group_id	= (isset($this->request->query['group_id'])) ? $this->request->query['group_id'] : $this->Session->read('Iroha.group_id');
-		$name				= (isset($this->request->query['name'])) ? $this->request->query['name'] : "";
+		$group_id = (isset($this->request->query['group_id'])) ? $this->request->query['group_id'] : $this->Session->read('Iroha.group_id');
+		$name     = (isset($this->request->query['name'])) ? $this->request->query['name'] : "";
+		$role     = ($this->request->query['role']) ? $this->request->query['role'] : 'user';
 
 		// 独自の検索条件を追加（指定したグループに所属するユーザを検索）
 		if($group_id != "")
@@ -231,8 +232,8 @@ class UsersController extends AppController
 					//'(SELECT group_concat(c.title order by c.id SEPARATOR \', \') as course_title FROM ib_users_courses uc INNER JOIN ib_courses c ON c.id = uc.course_id WHERE uc.user_id = User.id) as course_title',
 				),
 				'conditions' => $conditions,
-				'limit' => 1000,
-				'maxLimit' => 1000,
+				'limit' => 100,
+				'maxLimit' => 100,
 				'order' => 'username ASC',
 /*
 				'joins' => array(
@@ -248,38 +249,15 @@ class UsersController extends AppController
 */
 		));
 
-		// 受講生 -- user
+		// 取得するユーザ権限を指定
 		$user_conditions = array_merge($conditions,array(
-			'User.role' => 'user'
+			'User.role' => $role
 		));
 
 		$user_list = $this->User->find('all',array(
 			'conditions' => $user_conditions,
-			'order' => 'User.username asc'
-		));
-
-
-		// 管理者 -- admin
-
-		$admin_conditions = array_merge($conditions,array(
-			'User.role' => 'admin'
-		));
-
-		$admin_list = $this->User->find('all',array(
-			'conditions' => $admin_conditions,
-			'order' => 'User.username asc'
-		));
-
-
-		// 卒業生 -- graduate
-
-		$graduate_conditions = array_merge($conditions,array(
-			'User.role' => 'graduate'
-		));
-
-		$graduate_list = $this->User->find('all',array(
-			'conditions' => $graduate_conditions,
-			'order' => 'User.username asc'
+			'order' => 'User.username asc',
+			'recursive' => -1
 		));
 
 
@@ -297,8 +275,13 @@ class UsersController extends AppController
 
 		// グループ一覧を取得
 		$groups = $this->Group->find('list');
+		$roles = array(
+			'user'     => '受講生',
+			'admin'    => '管理者',
+			'graduate' => '卒業生'
+		);
 	
-		$this->set(compact('groups', 'user_list', 'admin_list', 'graduate_list' , 'group_id'));
+		$this->set(compact('groups', 'roles', 'role', 'user_list', 'group_id'));
 	}
 
 	/**

--- a/View/Users/admin_index.ctp
+++ b/View/Users/admin_index.ctp
@@ -2,7 +2,6 @@
 <style type="text/css">
 .radio-group{
 	position: relative;
-	top: -0.3rem;
 }
 .list-dot{
 	margin-top : .3rem !important;
@@ -15,27 +14,6 @@
 
 </style>
 
-<script>
-function changeDisplayList(obj){
-	let userListElement = document.getElementById('user-list');
-	let adminListElement = document.getElementById('admin-list');
-	let graduateListElement = document.getElementById('graduate-list');
-	if(obj['id'] == 'userList'){
-		userListElement.hidden = false;
-		adminListElement.hidden = true;
-		graduateListElement.hidden = true;
-		
-	}else if(obj['id'] == 'adminList'){
-		userListElement.hidden = true;
-		adminListElement.hidden = false;
-		graduateListElement.hidden = true;
-	}else if(obj['id'] == 'graduateList'){
-		userListElement.hidden = true;
-		adminListElement.hidden = true;
-		graduateListElement.hidden = false;
-	}
-}
-</script>
 <div class="admin-users-index full-view">
 	<div class="ib-page-title"><?php echo __('ユーザ一覧'); ?></div>
 	<div class="buttons_container">
@@ -61,27 +39,27 @@ function changeDisplayList(obj){
 			echo $this->Form->input('name',			array('label' => '氏名 or ふりがな: '  , 'required' => false));
 		?>
 		<input type="submit" class="btn btn-info btn-add" value="検索">
-		<?php
-			echo $this->Form->end();
-		?>
-	</div></br>
-	<div class="form-check radio-group">
-		<input class="form-check-input list-dot" type="radio" name="list-radio" id="userList" value="user_list" onClick="changeDisplayList(this)" checked>
-		<label class="from-check-label list-label" for="userList">受講生</label>
-
-		<input class="form-check-input list-dot" type="radio" name="list-radio" id="adminList" value="admin_list" onClick="changeDisplayList(this)">
-		<label class="from-check-label list-label" for="adminList">管理者</label>
-
-		<input class="form-check-input list-dot" type="radio" name="list-radio" id="graduateList" value="graduate_list" onClick="changeDisplayList(this)">
-		<label class="from-check-label list-label" for="graduateList">卒業生</label>
-
 	</div>
+	<br>
+	<div class="ib-horizontal form-check radio-group">
+		<?php
+			echo $this->Form->input('role', array(
+				'legend' => false,
+				'type' => 'radio',
+				'options' => $roles,
+				'value' => $role,
+				'onchange' => 'submit(this.form);'
+			));
+		?>
+	</div>
+	<?php echo $this->Form->end(); ?>
+	<br>
 
 	<table>
 		<thead>
 		<tr>
-		  <th nowrap style="width: 40px;"><?php echo __('No'); ?></th>
-  	  <th class="text-center"><?php echo __('写真'); ?></th>
+		    <th nowrap style="width: 40px;"><?php echo __('No'); ?></th>
+            <th class="text-center"><?php echo __('写真'); ?></th>
 			<th nowrap><?php echo $this->Paginator->sort('username', 'ログインID'); ?></th>
 			<th nowrap class="col-width"><?php echo $this->Paginator->sort('name', '氏名'); ?></th>
 			<th nowrap ><?php echo $this->Paginator->sort('name_furigana', 'ふりがな'); ?></th>
@@ -98,92 +76,6 @@ function changeDisplayList(obj){
 		<tbody id="user-list">
   	<?php $cnt = 1;?>
 		<?php foreach ($user_list as $user): ?>
-		<tr>
-			<td nowrap><?php echo h($cnt++);?></td>
-  	  <td align="center">
-  	  	<?php
-					$img_src = $this->Html->url(array(
-  	  			"controller" => "users",
-  	  			"action" => "show_picture",
-  	  			$user['User']['id']
-					), false);
-					echo $this->Html->link(
-						'<img src="'.$img_src.'" height="60" alt="'.h($user['User']['name']).'"/>',
-						array(
-							'controller' => 'users',
-							'action' => 'admin_edit',$user['User']['id']
-						),
-						array('escape' => false)
-					);
-				?>
-  	  </td>
-			<td><?php echo h($user['User']['username']); ?>&nbsp;</td>
-			<td><?php echo h($user['User']['name']); ?></td>
-			<td><?php echo h($user['User']['name_furigana']); ?></td>
-			<td nowrap><?php echo h(Configure::read('user_role.'.$user['User']['role'])); ?>&nbsp;</td>
-			<td><div class="reader" title="<?php echo h($user[0]['group_title']); ?>"><p><?php
-  	  $group_id = $user['User']['group_id'];
-  	  echo h($groups[$group_id]);
-
-  	  ?>&nbsp;</p></td>
-			<td class="ib-col-datetime"><?php echo h(Utils::getYMDHN($user['User']['last_logined'])); ?>&nbsp;</td>
-			<!-- <td class="ib-col-datetime"><?php echo h(Utils::getYMDHN($user['User']['created'])); ?>&nbsp;</td> -->
-			<?php if($loginedUser['role']=='admin') {?>
-			<td class="ib-col-action">
-				<button type="button" class="btn btn-success"
-					onclick="window.open('<?php echo Router::url(array('action' => 'edit', $user['User']['id']))?>', '_blank','width=900,height=600,resizable=no')">編集</button>
-			</td>
-			<?php }?>
-		</tr>
-		<?php endforeach; ?>
-		</tbody>
-
-		<tbody id="admin-list" hidden>
-  	<?php $cnt = 1;?>
-		<?php foreach ($admin_list as $user): ?>
-		<tr>
-			<td nowrap><?php echo h($cnt++);?></td>
-  	  <td align="center">
-  	  	<?php
-					$img_src = $this->Html->url(array(
-  	  			"controller" => "users",
-  	  			"action" => "show_picture",
-  	  			$user['User']['id']
-					), false);
-					echo $this->Html->link(
-						'<img src="'.$img_src.'" height="60" alt="'.h($user['User']['name']).'"/>',
-						array(
-							'controller' => 'users',
-							'action' => 'admin_edit',$user['User']['id']
-						),
-						array('escape' => false)
-					);
-				?>
-  	  </td>
-			<td><?php echo h($user['User']['username']); ?>&nbsp;</td>
-			<td><?php echo h($user['User']['name']); ?></td>
-			<td><?php echo h($user['User']['name_furigana']); ?></td>
-			<td nowrap><?php echo h(Configure::read('user_role.'.$user['User']['role'])); ?>&nbsp;</td>
-			<td><div class="reader" title="<?php echo h($user[0]['group_title']); ?>"><p><?php
-  	  $group_id = $user['User']['group_id'];
-  	  echo h($groups[$group_id]);
-
-  	  ?>&nbsp;</p></td>
-			<td class="ib-col-datetime"><?php echo h(Utils::getYMDHN($user['User']['last_logined'])); ?>&nbsp;</td>
-			<!-- <td class="ib-col-datetime"><?php echo h(Utils::getYMDHN($user['User']['created'])); ?>&nbsp;</td> -->
-			<?php if($loginedUser['role']=='admin') {?>
-			<td class="ib-col-action">
-				<button type="button" class="btn btn-success"
-					onclick="window.open('<?php echo Router::url(array('action' => 'edit', $user['User']['id']))?>', '_blank','width=900,height=600,resizable=no')">編集</button>
-			</td>
-			<?php }?>
-		</tr>
-		<?php endforeach; ?>
-		</tbody>
-
-		<tbody id="graduate-list" hidden>
-  	<?php $cnt = 1;?>
-		<?php foreach ($graduate_list as $user): ?>
 		<tr>
 			<td nowrap><?php echo h($cnt++);?></td>
   	  <td align="center">


### PR DESCRIPTION
find時のrecursive値を-1にして、不要なクエリを削除。
受講生・管理者・卒業生の全データを常に取得していたのを、その時に閲覧する権限のユーザデータのみ取得するように修正。