### PR TITLE
出欠情報にて「時限変更」機能を削除。

### DIFF
--- a/Config/ib_config.php
+++ b/Config/ib_config.php
@@ -203,7 +203,6 @@ $config["attendance_status"] = [
     "2" => "未定",
     "3" => "遅刻予定",
     "4" => "早退予定",
-    "5" => "時限変更",
 ];
 
 $config["attendance_status_for_edit"] = [
@@ -211,7 +210,6 @@ $config["attendance_status_for_edit"] = [
     "2" => "出席予定",
     "3" => "遅刻予定",
     "4" => "早退予定",
-    "5" => "時限変更",
 ];
 
 $config["attendance_status_for_admin_edit"] = [

--- a/View/Attendances/admin_index.ctp
+++ b/View/Attendances/admin_index.ctp
@@ -101,10 +101,6 @@ function downloadCSV()
 								$color = 'blue';
 								$mark  = '○(!)';
 								break;
-							case 5:  // 時限変更予定
-								$color = 'blue';
-								$mark  = '○(←→)';
-								break;
 						endswitch;
 				?>
 				<td nowrap><span style = "font-size : 15pt">
@@ -212,10 +208,6 @@ function downloadCSV()
 							case 4:  // 早退予定
 								$color = 'orange';
 								$mark  = '?(!)';
-								break;
-							case 5:  // 時限変更予定
-								$color = 'orange';
-								$mark  = '?(←→)';
 								break;
 						endswitch;
 				?>

--- a/View/UsersCourses/index.ctp
+++ b/View/UsersCourses/index.ctp
@@ -93,9 +93,6 @@
     									case 4:
     	    								echo __("早退");
     	    								break;
-										case 5:
-											echo __("時限変更");
-											break;
 										default:
 											echo __("出席予定");
 											break;


### PR DESCRIPTION
現在の教室では時限変更を利用しないので廃止