### PR TITLE
「初期受講コース」設定を実装。

### DIFF
--- a/Config/Schema/app.sql
+++ b/Config/Schema/app.sql
@@ -184,6 +184,7 @@ CREATE TABLE IF NOT EXISTS `ib_courses` (
   `user_id` int(8) NOT NULL,
   `before_course` int(8) DEFAULT NULL,
   `status` int(1) NOT NULL DEFAULT '1',
+  `initial_taken` int(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/Config/Schema/update.sql
+++ b/Config/Schema/update.sql
@@ -1,13 +1,1 @@
-SET FOREIGN_KEY_CHECKS=0;
-
-CREATE TABLE IF NOT EXISTS `ib_categories` (
-  `id` int(8) NOT NULL AUTO_INCREMENT,
-  `title` varchar(200) NOT NULL DEFAULT '',
-  `introduction` text,
-  `created` datetime DEFAULT NULL,
-  `modified` datetime DEFAULT NULL,
-  `sort_no` int(8) NOT NULL DEFAULT 0,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-SET FOREIGN_KEY_CHECKS=1;
+ALTER TABLE `ib_courses` ADD `initial_taken` int(1) NOT NULL DEFAULT '0';

--- a/Config/ib_config.php
+++ b/Config/ib_config.php
@@ -10,6 +10,7 @@
 
 $config["group_status"] = ["1" => "公開", "0" => "非公開"];
 $config["course_status"] = ["1" => "有効", "0" => "無効"];
+$config["initial_course"] = ["1" => "有効", "0" => "無効"];
 $config["content_status"] = ["1" => "公開", "0" => "非公開"];
 $config["content_kind"] = [
     "label" => "ラベル",

--- a/Controller/UsersController.php
+++ b/Controller/UsersController.php
@@ -11,6 +11,7 @@
 App::uses("AppController", "Controller");
 App::uses("Group", "Group");
 App::uses("Attendance", "Attendance");
+App::uses("UsersCourse", "UsersCourse");
 App::uses("CakeEmail", "Network/Email");
 
 /**
@@ -310,6 +311,8 @@ class UsersController extends AppController
         $group_list = $this->Group->find("list");
         $this->set("group_list", $group_list);
 
+        $this->loadModel("UsersCourse");
+
         $rows = $this->User->getOsList();
 
         $os_list = [];
@@ -359,6 +362,7 @@ class UsersController extends AppController
                         $user_id,
                         $period
                     );
+                    $this->UsersCourse->setInitialTakenCourses($user_id);
                 }
 
                 /*

--- a/View/Courses/admin_edit.ctp
+++ b/View/Courses/admin_edit.ctp
@@ -47,6 +47,17 @@
 					'options' => Configure::read('content_status')
 					)
 				);
+				echo $this->Form->input('initial_taken',	array(
+					'type' => 'radio',
+					'before' => '<label class="col col-sm-3 control-label">初期受講コース</label>',
+					'after' => '<span class="status-exp">　' . Configure::read('initial_course')[1] . 'と設定した場合、追加された受講生は自動でこのコースを受講可能になります。</span>',
+					'separator' => '　',
+					'legend' => false,
+					'class' => false,
+					'default' => 0,
+					'options' => Configure::read('initial_course'),
+					)
+				);
 				echo $this->Form->input('introduction',	array('label' => __('コース紹介')));
 				echo $this->Form->input('comment',		array('label' => __('備考')));
 			?>

--- a/View/Courses/admin_index.ctp
+++ b/View/Courses/admin_index.ctp
@@ -85,6 +85,8 @@
 						<thead>
 						<tr>
 							<th nowrap><?php echo __('コース名'); ?></th>
+							<th nowrap><?php echo __('公開/非公開'); ?></th>
+							<th nowrap><?php echo __('初期受講'); ?></th>
 							<th nowrap class="ib-col-datetime"><?php echo __('作成日時'); ?></th>
 							<th nowrap class="ib-col-datetime"><?php echo __('更新日時'); ?></th>
 							<th class="ib-col-action"><?php echo __('Actions'); ?></th>
@@ -99,6 +101,8 @@
 									echo $this->Form->hidden('id', array('id'=>'', 'class'=>$category_info['Category']['id'].'_id', 'value'=>$course['id']));
 								?>
 							</td>
+							<td nowrap><?php echo h(Configure::read('content_status.'.$course['status'])); ?></td>
+							<td nowrap><?php echo h(Configure::read('initial_course.'.$course['initial_taken'])); ?></td>
 							<td nowrap class="ib-col-datetime"><?php echo h(Utils::getYMDHN($course['created'])); ?>&nbsp;</td>
 							<td nowrap class="ib-col-datetime"><?php echo h(Utils::getYMDHN($course['modified'])); ?>&nbsp;</td>
 							<td class="ib-col-action">
@@ -139,6 +143,8 @@
 						<thead>
 						<tr>
 							<th nowrap><?php echo __('コース名'); ?></th>
+							<th nowrap><?php echo __('公開/非公開'); ?></th>
+							<th nowrap><?php echo __('初期受講'); ?></th>
 							<th nowrap class="ib-col-datetime"><?php echo __('作成日時'); ?></th>
 							<th nowrap class="ib-col-datetime"><?php echo __('更新日時'); ?></th>
 							<th class="ib-col-action"><?php echo __('Actions'); ?></th>
@@ -154,6 +160,8 @@
 									echo $this->Form->hidden('id', array('id'=>'', 'class'=>'0_id', 'value'=>$course['Course']['id']));
 								?>
 							</td>
+							<td nowrap><?php echo h(Configure::read('content_status.'.$course['Course']['status'])); ?></td>
+							<td nowrap><?php echo h(Configure::read('initial_course.'.$course['Course']['initial_taken'])); ?></td>
 							<td nowrap class="ib-col-datetime"><?php echo h(Utils::getYMDHN($course['Course']['created'])); ?>&nbsp;</td>
 							<td nowrap class="ib-col-datetime"><?php echo h(Utils::getYMDHN($course['Course']['modified'])); ?>&nbsp;</td>
 							<td class="ib-col-action">

--- a/View/Users/admin_index.ctp
+++ b/View/Users/admin_index.ctp
@@ -110,7 +110,7 @@
 			<?php if($loginedUser['role']=='admin') {?>
 			<td class="ib-col-action">
 				<button type="button" class="btn btn-success"
-					onclick="window.open('<?php echo Router::url(array('action' => 'edit', $user['User']['id']))?>', '_blank','width=900,height=600,resizable=no')">編集</button>
+					onclick="location.href='<?php echo Router::url(array('action' => 'edit', $user['User']['id']))?>'">編集</button>
 			</td>
 			<?php }?>
 		</tr>


### PR DESCRIPTION
この設定を有効にしておくと、受講生を追加した際に自動でそのコースを受講可能になる。

初期受講コースを追加した際に全受講生の設定が更新される機能は未実装。