### PR TITLE
SOAP記入画面にて、アンケート記録を取得する処理を修正。 

### DIFF
--- a/Controller/SoapsController.php
+++ b/Controller/SoapsController.php
@@ -61,11 +61,7 @@ class SoapsController extends AppController
         $input_max_length = 200;
         $this->set("input_max_length", $input_max_length);
 
-        //日付リスト
-        $today_date = isset($this->request->query["today_date"])
-            ? $this->request->query["today_date"]
-            : ["year" => date("Y"), "month" => date("m"), "day" => date("d")];
-        $this->set("today_date", $today_date);
+        $this->set("group_id", $group_id);
 
         // 最後の授業日
         $last_lecture_date_info = $this->Date->find("first", [
@@ -78,9 +74,59 @@ class SoapsController extends AppController
         ]);
         $last_lecture_date = $last_lecture_date_info["Date"]["date"];
 
+        //メンバーリスト
+        $user_list = $this->User->find("list", [
+            "conditions" => [
+                "role" => "user",
+            ],
+        ]);
+        $this->set("user_list", $user_list);
+
+        //グループ内の出席メンバーを探す
+        //$members = $this->User->findAllStudentInGroup($group_id);
+        $members = $this->Attendance->find("all", [
+            "fields" => [
+                "User.id",
+                "User.group_id"
+            ],
+            "conditions" => [
+                "User.group_id" => $group_id,
+                "Attendance.status" => 1,
+                "Attendance.login_time BETWEEN ? AND ?" => [
+                    $last_lecture_date,
+                    date("Y-m-d H:i:s"),
+                ]
+            ],
+            "order" => [
+                "User.username" => "ASC"
+            ],
+        ]);
+        $this->set("members", $members);
+
+        // グループ内ユーザのID一覧
+        $members_ids = array_map(function($member){
+                return $member['User']['id'];
+            },
+            $members
+        );
+
+        // user_idとpic_pathの配列
+        $group_pic_paths = $this->User->findGroupPicPaths($members);
+        $this->set("group_pic_paths", $group_pic_paths);
+
+        //グループ一覧を作り，配列の形を整形する
+        $group_list = $this->Group->find("list");
+        $this->set("group_list", $group_list);
+
+        //日付リスト
+        $today_date = isset($this->request->query["today_date"])
+            ? $this->request->query["today_date"]
+            : ["year" => date("Y"), "month" => date("m"), "day" => date("d")];
+        $this->set("today_date", $today_date);
+
         //提出したアンケートを検索（直近の授業日付）
         $conditions = [];
-        $conditions["Enquete.group_id"] = $group_id;
+        $conditions["Enquete.user_id"] = $members_ids;
         $conditions["Enquete.created BETWEEN ? AND ?"] = [
             $last_lecture_date,
             date("Y-m-d H:i:s"),
@@ -96,23 +142,6 @@ class SoapsController extends AppController
         }
 
         $this->set("enquete_inputted", $enquete_inputted);
-
-        //メンバーリスト
-
-        $user_list = $this->User->find("list");
-        $this->set("user_list", $user_list);
-
-        //グループ内のメンバーを探す
-        $members = $this->User->findAllStudentInGroup($group_id);
-        $this->set("members", $members);
-
-        // user_idとpic_pathの配列
-        $group_pic_paths = $this->User->findGroupPicPaths($members);
-        $this->set("group_pic_paths", $group_pic_paths);
-
-        //グループ一覧を作り，配列の形を整形する
-        $group_list = $this->Group->find("list");
-        $this->set("group_list", $group_list);
 
         //入力したSOAPを検索（前回の授業から）
         $conditions = [];
@@ -169,7 +198,7 @@ class SoapsController extends AppController
                 $today_date["day"];
 
             foreach ($soaps as &$soap) {
-                if (
+                if (  // S・O・A・Pのいずれも書かれていないものは保存しない
                     $soap["S"] == "" &&
                     $soap["O"] == "" &&
                     $soap["A"] == "" &&

--- a/View/Soaps/admin_group_edit.ctp
+++ b/View/Soaps/admin_group_edit.ctp
@@ -1,18 +1,19 @@
 <?php echo $this->element('admin_menu');?>
 <?php echo $this->Html->css('soap');?>
 <?php echo $this->Html->script('custom.js');?>
+<div><?php echo $this->Html->link(__('<< 戻る'), array('action' => 'find_by_group'))?></div>
 <div class = "admin-group_edit-index">
   <?php if (empty($members)): ?>
   <div class = "ib-page-title"><?php echo __('担当受講生がいません。')?></div>
   <?php else: ?>
-  <div class = "ib-page-title"><?php echo __('担当受講生一覧')?></div>
+  <div class = "ib-page-title"><?php echo h($group_list[$group_id])?>&nbsp;<?php echo __('担当受講生一覧')?></div>
   <br><br>
   <?php //$this->log($members);?>
   <?php foreach($members as $member):?>
   <div class = "member-input">
     <?php
 			$user_id = $member['User']['id'];
-			$group_id = $member['User']['group_id'];
+			//$group_id = $member['User']['group_id'];
     ?>
 	<script>
 	  $(function(){

--- a/View/Soaps/admin_id_edit.ctp
+++ b/View/Soaps/admin_id_edit.ctp
@@ -10,6 +10,7 @@ $(function(){
   setInputLengthChecker("<?php echo "#".$user_id."Comment"; ?>", <?php echo h($input_max_length); ?>);
 });
 </script>
+<div><?php echo $this->Html->link(__('<< 戻る'), array('controller' => 'soaprecords', 'action' => 'index'))?></div>
 <div class = "admin-student_edit-index">
   <div class = "ib-page-title"><?php echo __('SOAP編集')?></div>
   <br><br>

--- a/View/Soaps/admin_student_edit.ctp
+++ b/View/Soaps/admin_student_edit.ctp
@@ -10,6 +10,7 @@ $(function(){
   setInputLengthChecker("<?php echo "#".$user_id."Comment"; ?>", <?php echo h($input_max_length); ?>);
 });
 </script>
+<div><?php echo $this->Html->link(__('<< 戻る'), array('action' => 'find_by_student'))?></div>
 <div class = "admin-student_edit-index">
   <div class = "ib-page-title"><?php echo __('個別記入')?></div>
   <br><br>


### PR DESCRIPTION
アンケートの取得基準を「アンケートで選択されたグループ」から「ユーザ情報で設定されたグループ」に変更。
また、SOAPをグループ単位で記入する際、表示される受講生は直近の授業に出席した者のみに変更。