### PR TITLE
アンケート一覧とSOAP一覧に受講生番号を表示。デフォルトは受講生番号順で整列。

### DIFF
--- a/Controller/EnqueteController.php
+++ b/Controller/EnqueteController.php
@@ -330,7 +330,7 @@ class EnqueteController extends AppController
             }
 
             $this->Paginator->settings["conditions"] = $conditions;
-            $this->Paginator->settings["order"] = "Enquete.created desc";
+            $this->Paginator->settings["order"] = "User.username asc";
             $this->Paginator->settings["limit"] = 100;
             $this->Paginator->settings["maxLimit"] = 100;
             $this->Enquete->recursive = 0;

--- a/Controller/SoaprecordsController.php
+++ b/Controller/SoaprecordsController.php
@@ -200,7 +200,7 @@ class SoapRecordsController extends AppController
                 ];
             }
             $this->Paginator->settings["conditions"] = $conditions;
-            $this->Paginator->settings["order"] = "Soap.created desc";
+            $this->Paginator->settings["order"] = "User.username asc";
             $this->Paginator->settings["limit"] = 100;
             $this->Paginator->settings["maxLimit"] = 100;
             $this->Soap->recursive = 0;

--- a/View/Enquete/admin_index.ctp
+++ b/View/Enquete/admin_index.ctp
@@ -11,9 +11,9 @@ function downloadCSV()
 }
 
 function setTodayDate(){
-		$("#EnqueteCmd").val("today");
-		$("#EnqueteAdminIndexForm").submit();
-		$("#EnqueteCmd").val("");
+	$("#EnqueteCmd").val("today");
+	$("#EnqueteAdminIndexForm").submit();
+	$("#EnqueteCmd").val("");
 }
 
 function dis_item(obj, className){
@@ -159,9 +159,10 @@ function dis_item(obj, className){
 		<thead>
 			<tr>
 				<th nowrap　class="ib-col-center"><?php echo $this->Paginator->sort('Enquete.created','提出日時')?>
+				<th nowrap><?php echo $this->Paginator->sort('User.username', '受講生番号'); ?></th>
 				<th nowrap><?php echo $this->Paginator->sort('User.name', '氏名'); ?></th>
 				<th nowrap><?php echo $this->Paginator->sort('Enquete.group_id', '担当講師'); ?></th>
-				<th nowrap><?php echo $this->Paginator->sort('User.period', '所属'); ?></th>
+				<th nowrap><?php echo $this->Paginator->sort('User.period', '時限'); ?></th>
 				<th nowrap><?php echo $this->Paginator->sort('Enquete.today_impressions', '今日の感想'); ?></th>
 				<th nowrap class="beforeGoalCleared" style="display : none;"><?php echo $this->Paginator->sort('Enquete.before_goal_cleared', '前回T/F'); ?></th>
 				<th nowrap class="beforeFalseReason" style="display : none;"><?php echo $this->Paginator->sort('Enquete.before_false_reason', '前回F理由'); ?></th>
@@ -182,7 +183,8 @@ function dis_item(obj, className){
 			}
 		?>
 			<tr>
-				<td nowrap><?php echo h(Utils::getYMDHN($record['Enquete']['created'])); ?>&nbsp;</td>
+				<td nowrap><?php echo h(Utils::getYMD($record['Enquete']['created'])); ?>&nbsp;</td>
+				<td nowrap> <?php echo h($record['User']['username']); ?> </td>
 				<td nowrap>
 					<?php
 						echo $this->Html->link(h($record['User']['name']),

--- a/View/SoapRecords/admin_index.ctp
+++ b/View/SoapRecords/admin_index.ctp
@@ -93,9 +93,10 @@
 		<thead>
 			<tr>
 				<th class="ib-col-date"><?php echo $this->Paginator->sort('created', '受講日'); ?></th>
-				<th nowrap><?php echo $this->Paginator->sort('User.name', '受講生名'); ?></th>
-				<th nowrap><?php echo $this->Paginator->sort('group_id', '担当講師名'); ?></th>
-				<th nowrap class="text-center"><?php echo $this->Paginator->sort('User.period', '受講時限'); ?></th>
+				<th nowrap><?php echo $this->Paginator->sort('User.username', '受講生番号'); ?></th>
+				<th nowrap><?php echo $this->Paginator->sort('User.name', '氏名'); ?></th>
+				<th nowrap><?php echo $this->Paginator->sort('group_id', '担当講師'); ?></th>
+				<th nowrap class="text-center"><?php echo $this->Paginator->sort('User.period', '時限'); ?></th>
 				<th nowrap class="text-center"><?php echo $this->Paginator->sort('Course.title', '教材種別'); ?></th>
 				<th nowrap>SOAP</th>
 			</tr>
@@ -120,6 +121,7 @@
 						));
 					?>
 				</td>
+				<td> <?php echo h($record['User']['username']); ?> </td>
 				<td>
 					<?php
 						echo $this->Html->link(h($record['User']['name']),


### PR DESCRIPTION
アンケート一覧から提出時刻表示を削除。スペース確保が目的。